### PR TITLE
Allow interpolation of colors on the map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -252,6 +252,11 @@
         "moment": "^2.10.2"
       }
     },
+    "@types/chroma-js": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chroma-js/-/chroma-js-2.1.3.tgz",
+      "integrity": "sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g=="
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -841,6 +846,14 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true
     },
+    "chroma-js": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.1.1.tgz",
+      "integrity": "sha512-gYc5/Dooshun2OikK7oY/hYnoEiZ0dxqRpXosEdYRYm505vU5mRsHFqIW062C9nMtr32DVErP6mlxuepo2kNkw==",
+      "requires": {
+        "cross-env": "^6.0.3"
+      }
+    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -975,11 +988,18 @@
         "yaml": "^1.10.0"
       }
     },
+    "cross-env": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2408,8 +2428,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2944,8 +2963,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -3946,7 +3964,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -3954,8 +3971,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -4434,7 +4450,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "",
   "dependencies": {
     "@types/chart.js": "^2.9.24",
+    "@types/chroma-js": "^2.1.3",
     "@types/leaflet": "^1.5.17",
     "@types/topojson": "^3.2.2",
     "chart.js": "^2.9.3",
     "chartjs": "^0.3.24",
     "chartjs-plugin-zoom": "^0.7.7",
+    "chroma-js": "^2.1.1",
     "leaflet": "^1.7.1",
     "topojson": "^3.0.2"
   },

--- a/src/index.html
+++ b/src/index.html
@@ -70,8 +70,13 @@
       <h3>Settings</h3>
       <h4>Legende</h4>
       <form class="settings-form">
+        <label for="labelScheme">Farbschema</label><br />
         <input class="setting" type="radio" name="labelScheme" value="RKI" /> RKI (Einfach) <br />
         <input class="setting" type="radio" name="labelScheme" value="RiskLayer" /> RiskLayer (Feingranular) <br />
+        <br />
+        <label for="interpolate">Farbinterpolation</label><br />
+        <input class="setting" type="radio" name="interpolate" value="None" /> Keine <br />
+        <input class="setting" type="radio" name="interpolate" value="Linear" /> Lineare Interpolation <br />
       </form>
       
     </div>

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -5,12 +5,19 @@ export const enum LabelScheme {
   RiskLayer = 'RiskLayer'
 }
 
+export const enum Interpolation {
+  None = 'None',
+  Linear = 'Linear'
+}
+
 export type Settings = {
   labelScheme: LabelScheme,
+  interpolate: Interpolation,
 }
 
 const defaultSettings: Settings = {
   labelScheme: LabelScheme.RKI,
+  interpolate: Interpolation.None,
 };
 
 let currentSettings: Settings | null = null;
@@ -35,9 +42,9 @@ export function initCallbacks(): void {
     if(!isValidKey(key)){
       continue;
     }
-    
+
     uiElem.oninput = () => {
-      loadSettings()[key] = parseSetting(key, value) ?? defaultSettings[key];
+      updateSetting(key, value);
       storeSettings();
     };
   }
@@ -56,11 +63,16 @@ export function displayCurrentSettings(): void {
   }
 }
 
-function parseSetting<Key extends keyof Settings>(key: Key, value: string): Settings[Key]  | null{
-  if(key === 'labelScheme') {
-    return value === 'RKI' ? LabelScheme.RKI : LabelScheme.RiskLayer;
+function updateSetting<Key extends keyof Settings>(key: Key, value: string) {
+  loadSettings()[key] = defaultSettings[key];
+
+  if (key === 'labelScheme') {
+    loadSettings()['labelScheme'] = value === 'RKI' ? LabelScheme.RKI : LabelScheme.RiskLayer;
   }
-  return null;
+
+  if (key === 'interpolate') {
+    loadSettings()['interpolate'] = value === 'None' ? Interpolation.None : Interpolation.Linear;
+  }
 }
 
 function storeSettings(): void {


### PR DESCRIPTION
Especially in larger areas across multiple districts with identical incidence categories it is often hard to see "how bad" it is in each district compared to surrounding ones - the ranges get relatively big with higher incidence values.

By using a linear color interpolation you can easily identify hot spots in large high incidence clusters. Of course a map rendered with interpolated colors can no longer be easily used to derive the current rules that are applied to that area. Because of this the linear interpolation should be optional and off by default.

Please note my remarks on the code, there are a few place where I'm not really happy with how I solved it, especially the settings code.

An external library is used to interpolate the colors: [chroma-js](https://github.com/gka/chroma.js) (BSD license)